### PR TITLE
Add option for provision of mob path in command line.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,9 @@ PyMOAB has the following dependencies:
 2. (`numpy <http://www.numpy.org/>`_)
 3. (`MOAB <http://sigma.mcs.anl.gov/moab-library/>`_)
 
-PyMOAB relies on a prior installation of MAOB. The root location of this install should be added to the user environment in the variable `MOAB_PATH`. Along with this installation PyMOAB requires one small modification to the MOAB install. The TagInfo.hpp file found in the source must be copied/linked to the installation's include directory at './moab/TagInfo.hpp'.
+   PyMOAB relies on a prior installation of MOAB. The root location of this install should be added to the user environment in the variable `MOAB_PATH` or provided to the installation command as --moab-path=<moab_installation_dir>.
+
+   Along with this installation PyMOAB requires one small modification to the MOAB install. The TagInfo.hpp file found in the source must be copied/linked to the installation's include directory at './moab/TagInfo.hpp'.
 
 After these steps are complete PyMOAB can be installed using the command line:
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ After these steps are complete PyMOAB can be installed using the command line:
 
 OR
 
-``python setup.py install --user --moab-path=<moab_installation_dir>```
+```python setup.py install --user --moab-path=<moab_installation_dir>```
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,12 @@ PyMOAB has the following dependencies:
 
 After these steps are complete PyMOAB can be installed using the command line:
 
-```python setup.py install --user```
+```python setup.py install --user``` if the path is provided in the environment variable `MOAB_PATH`
+
+OR
+
+``python setup.py install --user --moab-path=<moab_installation_dir>```
+
 
 Testing
 -------

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,25 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-import os
+import sys, os
 import numpy as np
 from Cython.Build import cythonize
 
 moab_env_var = 'MOAB_PATH'
+moab_root = None
 
-try:
-    moab_root = os.environ[moab_env_var]
-except KeyError:
-    raise EnvironmentError('MOAB_PATH not found in environment.')
+for arg in sys.argv:
+    if "--moab-path" in arg:
+        moab_root = arg.split("=")[-1]
+        print "Set MOAB location with user-provided install path."
+        sys.argv.remove(arg)
 
+if moab_root is None:    
+    try:
+        moab_root = os.environ[moab_env_var]
+    except KeyError:
+        raise EnvironmentError('MOAB_PATH not found in environment.')
+    
 moab_include = moab_root + '/include/'
 moab_lib = moab_root + '/lib/'
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-import sys, os
+import os
+import sys
 import numpy as np
 from Cython.Build import cythonize
 
@@ -12,7 +13,7 @@ moab_default = '/usr/'
 #look for command line argument
 for arg in sys.argv:
     if "--moab-path" in arg:
-        moab_root = arg.split("=")[-1]
+        moab_root = arg.split("=", 1)[-1]
         print "Set MOAB location with user-provided install path."
         sys.argv.remove(arg)
 

--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,27 @@ from Cython.Build import cythonize
 
 moab_env_var = 'MOAB_PATH'
 moab_root = None
+moab_default = '/usr/'
 
+#look for command line argument
 for arg in sys.argv:
     if "--moab-path" in arg:
         moab_root = arg.split("=")[-1]
         print "Set MOAB location with user-provided install path."
         sys.argv.remove(arg)
 
+#search environment for moab install
 if moab_root is None:
     try:
         moab_root = os.environ[moab_env_var]
     except KeyError:
-        raise EnvironmentError('MOAB_PATH not found in environment.')
+        #as a last attempt, check the root location
+        if os.path.isfile(moab_default+'/include/moab/Core.hpp'):
+            moab_root = moab_default
+        else:
+            raise EnvironmentError('MOAB_PATH not found in environment.')
 
+#check that the moab location is legitimate
 if not os.path.isfile(moab_root+'/include/moab/Core.hpp'):
     raise StandardError('Provided MOAB location is invalid.')
 

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,15 @@ for arg in sys.argv:
         print "Set MOAB location with user-provided install path."
         sys.argv.remove(arg)
 
-if moab_root is None:    
+if moab_root is None:
     try:
         moab_root = os.environ[moab_env_var]
     except KeyError:
         raise EnvironmentError('MOAB_PATH not found in environment.')
+
+if not os.path.isfile(moab_root+'/include/moab/Core.hpp'):
+    raise StandardError('Provided MOAB location is invalid.')
+
     
 moab_include = moab_root + '/include/'
 moab_lib = moab_root + '/lib/'


### PR DESCRIPTION
Includes command line option for pymoab build as well as a default location if all else fails. Default location is looking for the aptitude install of MOAB recently provided by a SIGMA contributor. 

The command line option is found by looping over sys.argv. There were other, more proper options for doing this, like creating a custom command for the distutils setup and using it in place of the current install command. It seemed like a heavy hammer for the task at hand and I went with this. Definitely willing to do this another way if needed.
