### PR TITLE
Interface updates

### DIFF
--- a/examples/yt2moab.py
+++ b/examples/yt2moab.py
@@ -22,7 +22,7 @@ def yt2moab_uniform_gridgen(mb,ds):
     """Generates a uniform grid in a moab instance (mb) meshset which is representative of the yt grid dataset (ds)"""
 
     #create a meshset for this grid
-    msh = mb.create_meshset(1)
+    msh = mb.create_meshset()
 
     domain = ds.domain_dimensions
 

--- a/pymoab/core.pyx
+++ b/pymoab/core.pyx
@@ -30,9 +30,10 @@ cdef class Core(object):
         cdef const char * file_name = cfname
         self.inst.write_file(fname)
 
-    def create_meshset(self, unsigned int options):
+    def create_meshset(self, unsigned int options = 0x02 ):
         cdef moab.EntityHandle ms_handle = 0
-        cdef moab.ErrorCode err = self.inst.create_meshset(options, ms_handle)
+        cdef moab.EntitySetProperty es_property = <moab.EntitySetProperty> options 
+        cdef moab.ErrorCode err = self.inst.create_meshset(es_property, ms_handle)
         check_error(err)
         return ms_handle
 

--- a/pymoab/core.pyx
+++ b/pymoab/core.pyx
@@ -30,7 +30,7 @@ cdef class Core(object):
         cdef const char * file_name = cfname
         self.inst.write_file(fname)
 
-    def create_meshset(self, unsigned int options = 0x02 ):
+    def create_meshset(self, unsigned int options = 0x02):
         cdef moab.EntityHandle ms_handle = 0
         cdef moab.EntitySetProperty es_property = <moab.EntitySetProperty> options 
         cdef moab.ErrorCode err = self.inst.create_meshset(es_property, ms_handle)

--- a/pymoab/moab.pxd
+++ b/pymoab/moab.pxd
@@ -5,6 +5,11 @@ from libcpp.string cimport string as std_string
 
 cdef extern from "moab/Types.hpp" namespace "moab":
 
+    ctypedef enum EntitySetProperty:
+        MESHSET_TRACK_OWNER = 0x01
+        MESHSET_SET = 0x02
+        MESHSET_ORDERED = 0x03
+
     cdef enum DataType:
         MB_TYPE_OPAQUE   = 0
         MB_TYPE_INTEGER  = 1


### PR DESCRIPTION
Adding the proper types to be passed along to MOAB for the creation of meshsets and added a default value for this type so calls now look like 

```
mb.create_meshset()
```

rather than 

```
mb.create_meshset(1)
```

with an unexplained integer argument.
