### PR TITLE
Check Error updates

### DIFF
--- a/pymoab/core.pyx
+++ b/pymoab/core.pyx
@@ -24,21 +24,21 @@ cdef class Core(object):
         """MOAB implementation number as a float."""
         return self.inst.impl_version()
 
-    def write_file(self, str fname, exceptions = []):
+    def write_file(self, str fname, exceptions = ()):
         """Writes the MOAB data to a file."""
         cfname = fname.decode()
         cdef const char * file_name = cfname
         cdef moab.ErrorCode err = self.inst.write_file(fname)
         check_error(err, exceptions)
 
-    def create_meshset(self, unsigned int options = 0x02, exceptions = []):
+    def create_meshset(self, unsigned int options = 0x02, exceptions = ()):
         cdef moab.EntityHandle ms_handle = 0
         cdef moab.EntitySetProperty es_property = <moab.EntitySetProperty> options 
         cdef moab.ErrorCode err = self.inst.create_meshset(es_property, ms_handle)
         check_error(err, exceptions)
         return ms_handle
 
-    def add_entities(self, moab.EntityHandle ms_handle, entities, exceptions = []):
+    def add_entities(self, moab.EntityHandle ms_handle, entities, exceptions = ()):
         cdef moab.ErrorCode err
         cdef Range r
         cdef np.ndarray[np.uint64_t, ndim=1] arr         
@@ -50,7 +50,7 @@ cdef class Core(object):
            err = self.inst.add_entities(ms_handle, <unsigned long*> arr.data, len(entities))
         check_error(err, exceptions)
 
-    def create_vertices(self, np.ndarray[np.float64_t, ndim=1] coordinates, exceptions = []):
+    def create_vertices(self, np.ndarray[np.float64_t, ndim=1] coordinates, exceptions = ()):
         cdef Range rng = Range()
         cdef moab.ErrorCode err = self.inst.create_vertices(<double *> coordinates.data, 
                                                             len(coordinates)//3,
@@ -58,7 +58,7 @@ cdef class Core(object):
         check_error(err, exceptions)
         return rng
 
-    def create_element(self, int t, np.ndarray[np.uint64_t, ndim=1] connectivity, exceptions = []):
+    def create_element(self, int t, np.ndarray[np.uint64_t, ndim=1] connectivity, exceptions = ()):
         cdef moab.EntityType typ = <moab.EntityType> t
         cdef moab.EntityHandle handle = 0
         cdef int nnodes = len(connectivity)
@@ -67,7 +67,7 @@ cdef class Core(object):
         check_error(err, exceptions)
         return handle
 
-    def create_elements(self, int t, np.ndarray[np.uint64_t, ndim=2] connectivity, exceptions = []):
+    def create_elements(self, int t, np.ndarray[np.uint64_t, ndim=2] connectivity, exceptions = ()):
         cdef int i
         cdef moab.ErrorCode err
         cdef moab.EntityType typ = <moab.EntityType> t
@@ -83,13 +83,13 @@ cdef class Core(object):
             check_error(err, exceptions)
         return handles
 
-    def tag_get_handle(self, const char* name, int size, moab.DataType type, exceptions = []):
+    def tag_get_handle(self, const char* name, int size, moab.DataType type, exceptions = ()):
         cdef Tag tag = Tag()
         cdef moab.ErrorCode err = self.inst.tag_get_handle(name, size, type, tag.inst, types.MB_TAG_DENSE|types.MB_TAG_CREAT)
         check_error(err, exceptions)
         return tag
     
-    def tag_set_data(self, Tag tag, np.ndarray[np.uint64_t, ndim=1] entity_handles, np.ndarray data, exceptions = []):
+    def tag_set_data(self, Tag tag, np.ndarray[np.uint64_t, ndim=1] entity_handles, np.ndarray data, exceptions = ()):
         cdef moab.ErrorCode err
         cdef Range r
         cdef np.ndarray[np.uint64_t, ndim=1] arr

--- a/pymoab/core.pyx
+++ b/pymoab/core.pyx
@@ -24,20 +24,21 @@ cdef class Core(object):
         """MOAB implementation number as a float."""
         return self.inst.impl_version()
 
-    def write_file(self, str fname):
+    def write_file(self, str fname, exceptions = None):
         """Writes the MOAB data to a file."""
         cfname = fname.decode()
         cdef const char * file_name = cfname
-        self.inst.write_file(fname)
+        cdef moab.ErrorCode err = self.inst.write_file(fname)
+        check_error(err, exceptions)
 
-    def create_meshset(self, unsigned int options = 0x02):
+    def create_meshset(self, unsigned int options = 0x02, exceptions = None):
         cdef moab.EntityHandle ms_handle = 0
         cdef moab.EntitySetProperty es_property = <moab.EntitySetProperty> options 
         cdef moab.ErrorCode err = self.inst.create_meshset(es_property, ms_handle)
-        check_error(err)
+        check_error(err, exceptions)
         return ms_handle
 
-    def add_entities(self, moab.EntityHandle ms_handle, entities):
+    def add_entities(self, moab.EntityHandle ms_handle, entities, exceptions = None):
         cdef moab.ErrorCode err
         cdef Range r
         cdef np.ndarray[np.uint64_t, ndim=1] arr         
@@ -47,26 +48,26 @@ cdef class Core(object):
         else:
            arr = entities
            err = self.inst.add_entities(ms_handle, <unsigned long*> arr.data, len(entities))
-        check_error(err)
+        check_error(err, exceptions)
 
-    def create_vertices(self, np.ndarray[np.float64_t, ndim=1] coordinates):
+    def create_vertices(self, np.ndarray[np.float64_t, ndim=1] coordinates, exceptions = None):
         cdef Range rng = Range()
         cdef moab.ErrorCode err = self.inst.create_vertices(<double *> coordinates.data, 
                                                             len(coordinates)//3,
                                                             deref(rng.inst))
-        check_error(err)
+        check_error(err, exceptions)
         return rng
 
-    def create_element(self, int t, np.ndarray[np.uint64_t, ndim=1] connectivity):
+    def create_element(self, int t, np.ndarray[np.uint64_t, ndim=1] connectivity, exceptions = None):
         cdef moab.EntityType typ = <moab.EntityType> t
         cdef moab.EntityHandle handle = 0
         cdef int nnodes = len(connectivity)
         cdef moab.ErrorCode err = self.inst.create_element(typ,
             <unsigned long*> connectivity.data, nnodes, handle)
-        check_error(err)
+        check_error(err, exceptions)
         return handle
 
-    def create_elements(self, int t, np.ndarray[np.uint64_t, ndim=2] connectivity):
+    def create_elements(self, int t, np.ndarray[np.uint64_t, ndim=2] connectivity, exceptions = None):
         cdef int i
         cdef moab.ErrorCode err
         cdef moab.EntityType typ = <moab.EntityType> t
@@ -79,16 +80,16 @@ cdef class Core(object):
             connectivity_i = connectivity[i]
             err = self.inst.create_element(typ, <unsigned long*> connectivity_i.data,
                                            nnodes, deref((<unsigned long*> handles.data)+i))
-            check_error(err)
+            check_error(err, exceptions)
         return handles
 
-    def tag_get_handle(self, const char* name, int size, moab.DataType type):
+    def tag_get_handle(self, const char* name, int size, moab.DataType type, exceptions = None):
         cdef Tag tag = Tag()
         cdef moab.ErrorCode err = self.inst.tag_get_handle(name, size, type, tag.inst, types.MB_TAG_DENSE|types.MB_TAG_CREAT)
-        check_error(err)
+        check_error(err, exceptions)
         return tag
     
-    def tag_set_data(self, Tag tag, np.ndarray[np.uint64_t, ndim=1] entity_handles, np.ndarray data):
+    def tag_set_data(self, Tag tag, np.ndarray[np.uint64_t, ndim=1] entity_handles, np.ndarray data, exceptions = None):
         cdef moab.ErrorCode err
         cdef Range r
         cdef np.ndarray[np.uint64_t, ndim=1] arr
@@ -98,5 +99,5 @@ cdef class Core(object):
         else:
             arr = entity_handles
             err = self.inst.tag_set_data(tag.inst, <unsigned long*> arr.data, len(entity_handles), <const void*> data.data)
-        check_error(err)
+        check_error(err, exceptions)
     

--- a/pymoab/core.pyx
+++ b/pymoab/core.pyx
@@ -24,21 +24,21 @@ cdef class Core(object):
         """MOAB implementation number as a float."""
         return self.inst.impl_version()
 
-    def write_file(self, str fname, exceptions = None):
+    def write_file(self, str fname, exceptions = []):
         """Writes the MOAB data to a file."""
         cfname = fname.decode()
         cdef const char * file_name = cfname
         cdef moab.ErrorCode err = self.inst.write_file(fname)
-        check_error(err, exceptions = exceptions)
+        check_error(err, exceptions)
 
-    def create_meshset(self, unsigned int options = 0x02, exceptions = None):
+    def create_meshset(self, unsigned int options = 0x02, exceptions = []):
         cdef moab.EntityHandle ms_handle = 0
         cdef moab.EntitySetProperty es_property = <moab.EntitySetProperty> options 
         cdef moab.ErrorCode err = self.inst.create_meshset(es_property, ms_handle)
-        check_error(err, exceptions = exceptions)
+        check_error(err, exceptions)
         return ms_handle
 
-    def add_entities(self, moab.EntityHandle ms_handle, entities, exceptions = None):
+    def add_entities(self, moab.EntityHandle ms_handle, entities, exceptions = []):
         cdef moab.ErrorCode err
         cdef Range r
         cdef np.ndarray[np.uint64_t, ndim=1] arr         
@@ -48,26 +48,26 @@ cdef class Core(object):
         else:
            arr = entities
            err = self.inst.add_entities(ms_handle, <unsigned long*> arr.data, len(entities))
-        check_error(err, exceptions = exceptions)
+        check_error(err, exceptions)
 
-    def create_vertices(self, np.ndarray[np.float64_t, ndim=1] coordinates, exceptions = None):
+    def create_vertices(self, np.ndarray[np.float64_t, ndim=1] coordinates, exceptions = []):
         cdef Range rng = Range()
         cdef moab.ErrorCode err = self.inst.create_vertices(<double *> coordinates.data, 
                                                             len(coordinates)//3,
                                                             deref(rng.inst))
-        check_error(err, exceptions = exceptions)
+        check_error(err, exceptions)
         return rng
 
-    def create_element(self, int t, np.ndarray[np.uint64_t, ndim=1] connectivity, exceptions = None):
+    def create_element(self, int t, np.ndarray[np.uint64_t, ndim=1] connectivity, exceptions = []):
         cdef moab.EntityType typ = <moab.EntityType> t
         cdef moab.EntityHandle handle = 0
         cdef int nnodes = len(connectivity)
         cdef moab.ErrorCode err = self.inst.create_element(typ,
             <unsigned long*> connectivity.data, nnodes, handle)
-        check_error(err, exceptions = exceptions)
+        check_error(err, exceptions)
         return handle
 
-    def create_elements(self, int t, np.ndarray[np.uint64_t, ndim=2] connectivity, exceptions = None):
+    def create_elements(self, int t, np.ndarray[np.uint64_t, ndim=2] connectivity, exceptions = []):
         cdef int i
         cdef moab.ErrorCode err
         cdef moab.EntityType typ = <moab.EntityType> t
@@ -80,16 +80,16 @@ cdef class Core(object):
             connectivity_i = connectivity[i]
             err = self.inst.create_element(typ, <unsigned long*> connectivity_i.data,
                                            nnodes, deref((<unsigned long*> handles.data)+i))
-            check_error(err, exceptions = exceptions)
+            check_error(err, exceptions)
         return handles
 
-    def tag_get_handle(self, const char* name, int size, moab.DataType type, exceptions = None):
+    def tag_get_handle(self, const char* name, int size, moab.DataType type, exceptions = []):
         cdef Tag tag = Tag()
         cdef moab.ErrorCode err = self.inst.tag_get_handle(name, size, type, tag.inst, types.MB_TAG_DENSE|types.MB_TAG_CREAT)
-        check_error(err, exceptions = exceptions)
+        check_error(err, exceptions)
         return tag
     
-    def tag_set_data(self, Tag tag, np.ndarray[np.uint64_t, ndim=1] entity_handles, np.ndarray data, exceptions = None):
+    def tag_set_data(self, Tag tag, np.ndarray[np.uint64_t, ndim=1] entity_handles, np.ndarray data, exceptions = []):
         cdef moab.ErrorCode err
         cdef Range r
         cdef np.ndarray[np.uint64_t, ndim=1] arr
@@ -99,5 +99,5 @@ cdef class Core(object):
         else:
             arr = entity_handles
             err = self.inst.tag_set_data(tag.inst, <unsigned long*> arr.data, len(entity_handles), <const void*> data.data)
-        check_error(err, exceptions = exceptions)
+        check_error(err, exceptions)
     

--- a/pymoab/core.pyx
+++ b/pymoab/core.pyx
@@ -29,13 +29,13 @@ cdef class Core(object):
         cfname = fname.decode()
         cdef const char * file_name = cfname
         cdef moab.ErrorCode err = self.inst.write_file(fname)
-        check_error(err, exceptions)
+        check_error(err, exceptions = exceptions)
 
     def create_meshset(self, unsigned int options = 0x02, exceptions = None):
         cdef moab.EntityHandle ms_handle = 0
         cdef moab.EntitySetProperty es_property = <moab.EntitySetProperty> options 
         cdef moab.ErrorCode err = self.inst.create_meshset(es_property, ms_handle)
-        check_error(err, exceptions)
+        check_error(err, exceptions = exceptions)
         return ms_handle
 
     def add_entities(self, moab.EntityHandle ms_handle, entities, exceptions = None):
@@ -48,14 +48,14 @@ cdef class Core(object):
         else:
            arr = entities
            err = self.inst.add_entities(ms_handle, <unsigned long*> arr.data, len(entities))
-        check_error(err, exceptions)
+        check_error(err, exceptions = exceptions)
 
     def create_vertices(self, np.ndarray[np.float64_t, ndim=1] coordinates, exceptions = None):
         cdef Range rng = Range()
         cdef moab.ErrorCode err = self.inst.create_vertices(<double *> coordinates.data, 
                                                             len(coordinates)//3,
                                                             deref(rng.inst))
-        check_error(err, exceptions)
+        check_error(err, exceptions = exceptions)
         return rng
 
     def create_element(self, int t, np.ndarray[np.uint64_t, ndim=1] connectivity, exceptions = None):
@@ -64,7 +64,7 @@ cdef class Core(object):
         cdef int nnodes = len(connectivity)
         cdef moab.ErrorCode err = self.inst.create_element(typ,
             <unsigned long*> connectivity.data, nnodes, handle)
-        check_error(err, exceptions)
+        check_error(err, exceptions = exceptions)
         return handle
 
     def create_elements(self, int t, np.ndarray[np.uint64_t, ndim=2] connectivity, exceptions = None):
@@ -80,13 +80,13 @@ cdef class Core(object):
             connectivity_i = connectivity[i]
             err = self.inst.create_element(typ, <unsigned long*> connectivity_i.data,
                                            nnodes, deref((<unsigned long*> handles.data)+i))
-            check_error(err, exceptions)
+            check_error(err, exceptions = exceptions)
         return handles
 
     def tag_get_handle(self, const char* name, int size, moab.DataType type, exceptions = None):
         cdef Tag tag = Tag()
         cdef moab.ErrorCode err = self.inst.tag_get_handle(name, size, type, tag.inst, types.MB_TAG_DENSE|types.MB_TAG_CREAT)
-        check_error(err, exceptions)
+        check_error(err, exceptions = exceptions)
         return tag
     
     def tag_set_data(self, Tag tag, np.ndarray[np.uint64_t, ndim=1] entity_handles, np.ndarray data, exceptions = None):
@@ -99,5 +99,5 @@ cdef class Core(object):
         else:
             arr = entity_handles
             err = self.inst.tag_set_data(tag.inst, <unsigned long*> arr.data, len(entity_handles), <const void*> data.data)
-        check_error(err, exceptions)
+        check_error(err, exceptions = exceptions)
     

--- a/pymoab/types.pyx
+++ b/pymoab/types.pyx
@@ -45,10 +45,11 @@ def check_error(int err, **kwargs):
     """Checks error status code and raises error if needed."""
     if 'exceptions' in kwargs:
         exceptions = kwargs['exceptions']
-        for exception in exceptions:
-            if err == exception: return
+        if isinstance (exceptions,(list,tuple)):
+            for exception in exceptions:
+                if err == exception: return
     if 'exceptions' in kwargs and kwargs['exceptions'] == err:
-        return
+            return
     if err == moab.MB_SUCCESS:
         return
     errtype, msg = _ERROR_MSGS[err]

--- a/pymoab/types.pyx
+++ b/pymoab/types.pyx
@@ -41,14 +41,10 @@ cdef dict _ERROR_MSGS = {
     MB_FAILURE: (RuntimeError, '[MOAB] failure'),
     }
 
-def check_error(int err, **kwargs):
+def check_error(int err, list exceptions, **kwargs):
     """Checks error status code and raises error if needed."""
-    if 'exceptions' in kwargs:
-        exceptions = kwargs['exceptions']
-        if isinstance (exceptions,(list,tuple)):
-            for exception in exceptions:
-                if err == exception: return
-    if 'exceptions' in kwargs and kwargs['exceptions'] == err:
+    for exception in exceptions:
+        if exception == err:
             return
     if err == moab.MB_SUCCESS:
         return

--- a/pymoab/types.pyx
+++ b/pymoab/types.pyx
@@ -43,7 +43,13 @@ cdef dict _ERROR_MSGS = {
 
 def check_error(int err, **kwargs):
     """Checks error status code and raises error if needed."""
-    if err == 0:
+    if 'except_errs' in kwargs:
+        exceptions = kwargs['except_errs']
+        for exception in exceptions:
+            if err == exception: return
+    if 'except_err' in kwargs and kwargs['except_err'] == err:
+        return
+    if err == moab.MB_SUCCESS:
         return
     errtype, msg = _ERROR_MSGS[err]
     if len(kwargs) > 0:

--- a/pymoab/types.pyx
+++ b/pymoab/types.pyx
@@ -43,11 +43,11 @@ cdef dict _ERROR_MSGS = {
 
 def check_error(int err, **kwargs):
     """Checks error status code and raises error if needed."""
-    if 'except_errs' in kwargs:
-        exceptions = kwargs['except_errs']
+    if 'exceptions' in kwargs:
+        exceptions = kwargs['exceptions']
         for exception in exceptions:
             if err == exception: return
-    if 'except_err' in kwargs and kwargs['except_err'] == err:
+    if 'exceptions' in kwargs and kwargs['exceptions'] == err:
         return
     if err == moab.MB_SUCCESS:
         return

--- a/pymoab/types.pyx
+++ b/pymoab/types.pyx
@@ -41,7 +41,7 @@ cdef dict _ERROR_MSGS = {
     MB_FAILURE: (RuntimeError, '[MOAB] failure'),
     }
 
-def check_error(int err, list exceptions, **kwargs):
+def check_error(int err, tuple exceptions, **kwargs):
     """Checks error status code and raises error if needed."""
     for exception in exceptions:
         if exception == err:


### PR DESCRIPTION
Last PR for a bit on this. Adding the capability for exceptions to returned errorcodes coming from MOAB. I'm hoping there is some discussion behind this one. I'd particularly like some input from @vijaysm. I'd like to make sure the user knows that the option for adding error exceptions is available as MOAB is not designed s.t. MB_SUCCESS is a required return behavior for the ErrorCode.

Maybe a part of this PR should be documentation for the existing functions so users are easily aware of this capability?
