### PR TITLE
Range bug fix

### DIFF
--- a/pymoab/range.pyx
+++ b/pymoab/range.pyx
@@ -33,6 +33,11 @@ cdef class Range(object):
         """clears the contents of the list."""
         self.inst.clear()
 
+    def __iter__(self):
+        cdef int i = 0
+        for i in range(0, self.inst.size()):
+            yield self[i]
+            
     def __getitem__(self, int index):
         cdef moab.EntityHandle rtn = deref(self.inst)[index]
         return rtn

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -112,6 +112,12 @@ def test_range():
     data = np.array((1,))
     mb.tag_set_data(test_tag,vert,data)
 
+    dum = 0
+    for v in vert:
+        dum += 1
+        if dum > 100: break
+    assert vert.size() is dum
+
 def test_tag_failures():
 
     mb = core.Core()


### PR DESCRIPTION
This fixes the problem with successfully iterating over a Range by raising a StopIteration at the appropriate time. If there is a better way to do this by exposing an iterator on the C++ side, I'm happy to attempt that as well.
